### PR TITLE
Menu: Change breakpoint for sidebar to 'small' instead of 'medium'

### DIFF
--- a/dt-assets/parts/nav-topbar.php
+++ b/dt-assets/parts/nav-topbar.php
@@ -32,7 +32,7 @@ $dt_nav_tabs = dt_default_menu_array();
 
 <!--  /* TOP LEFT SIDE MENU AREA */ -->
 <div data-sticky-container>
-    <div class="title-bar hide-for-large" data-sticky data-responsive-toggle="top-bar-menu" data-margin-top="0" data-sticky-on="medium">
+    <div class="title-bar show-for-small-only" data-sticky data-responsive-toggle="top-bar-menu" data-margin-top="0" data-sticky-on="medium">
 
         <div class="title-bar-left">
 
@@ -104,7 +104,7 @@ $dt_nav_tabs = dt_default_menu_array();
 </div>
 
 <!--  /* LOGO AREA */ -->
-<div data-sticky-container class="show-for-large">
+<div data-sticky-container class="hide-for-small-only">
     <div class="top-bar" id="top-bar-menu"
          data-sticky style="width:100%;margin-top:0">
         <div>


### PR DESCRIPTION
A suggestion.
I've been wanting to try this for a while and the navigation dropdown you just implemented opens up the opportunity.
I find the medium breakpoint to be too soon. I don't like the side bar navigation as much.

The top bar does get crowded tho:
![image](https://user-images.githubusercontent.com/24901539/125318575-93d9e280-e2ff-11eb-88ca-98c6ef85ffb6.png)
